### PR TITLE
Fix incorrect Kube readiness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@
 [![Build Status](https://travis-ci.org/xuanzhaopeng/slim-zalenium.svg?branch=master)](https://travis-ci.org/xuanzhaopeng/slim-zalenium)
 
 > This project is customised version of zelenium,  if you'd like to check zalenium, pls navigate to zalando/zalenium,  otherwise, current code is still in beta version
+
+## How to release
+```
+./release.sh release 3.141.59-1.0.0
+git push origin --tags
+```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.iqalab</groupId>
     <artifactId>slim-zalenium</artifactId>
-    <version>3.141.59-1.0.0</version>
+    <version>3.141.59-1.1.0</version>
     <name>Slim Zalenium</name>
     <description>An customised version based on Zalando open sourced project Zalenium 3.141.59z</description>
 

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -678,7 +678,7 @@ public class KubernetesContainerClient implements ContainerClient {
                         // so then we can initiate a registration.
                         .withNewReadinessProbe()
                             .withNewExec()
-                                .addToCommand(new String[] {"/bin/sh", "-c", "http_proxy=\"\" curl -s http://`hostname -i`:"
+                                .addToCommand(new String[] {"curl -s http://`hostname -i`:"
                                         + config.getNodePort() + "/wd/hub/status | jq .value.ready | grep true"})
                             .endExec()
                             .withInitialDelaySeconds(5)


### PR DESCRIPTION
Here is how created work node looks like in eks-fargate, 

```
Name:                 zalenium-40000-tjbwj
...
Annotations:          kubernetes.io/psp: eks.privileged
Status:               Running
IP:                   10.0.2.183
IPs:
  IP:           10.0.2.183
Controlled By:  Pod/zalenium-dd6dc6bf5-t87xx
Containers:
  selenium-node:
    Container ID:   containerd://3c2b2490bfa922ce24cf238a48abf25ae52222b62841d68ef1ea39c317c91f5b
    Image:          elgalu/selenium
    Image ID:       docker.io/elgalu/selenium@sha256:84288fdb088993fead6571fa735c636e2509f4a765409e5caa0e3ab83762decc
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Wed, 14 Oct 2020 23:19:33 +0200
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  2Gi
    Requests:
      cpu:      250m
      memory:   500Mi
    Readiness:  exec [/bin/sh -c http_proxy="" curl -s http://`hostname -i`:40000/wd/hub/status | jq .value.ready | grep true] delay=5s timeout=5s period=1s #success=1 #failure=60
    ...

Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  5m8s                   fargate-scheduler  Successfully assigned zalenium/zalenium-40000-tjbwj to fargate-ip-10-0-2-183.eu-central-1.compute.internal
  Normal   Pulling    5m8s                   kubelet            Pulling image "elgalu/selenium"
  Normal   Pulled     2m41s                  kubelet            Successfully pulled image "elgalu/selenium"
  Normal   Created    2m36s                  kubelet            Created container selenium-node
  Normal   Started    2m35s                  kubelet            Started container selenium-node
  Warning  Unhealthy  2m8s (x21 over 2m29s)  kubelet            Readiness probe failed:
```

`  Warning  Unhealthy  2m8s (x21 over 2m29s)  kubelet            Readiness probe failed:` always there because readiness is failed.

the readiness code is :
```
/bin/sh -c http_proxy="" curl -s http://`hostname -i`:40000/wd/hub/status | jq .value.ready | grep true
```

so change the readiness to following code will resolve the issue
```
curl -s http://`hostname -i`:40000/wd/hub/status | jq .value.ready | grep true
```

